### PR TITLE
change error message when PUT is incorrect

### DIFF
--- a/webapp/server.js
+++ b/webapp/server.js
@@ -31,7 +31,7 @@ app.get('/api/v1.0/toppings/:id', function(req, res) {
 app.put('/api/v1.0/toppings/:id', function(req, res) {
   if(!req.body.hasOwnProperty('title')) {
     res.statusCode = 400;
-    return res.send('Error 400: Post syntax incorrect.');
+    return res.send('Error 400: PUT syntax incorrect.');
   }
 
   toppings.toppings[req.params.id -1] = {


### PR DESCRIPTION
Error message is misleading, when PUT is incorrect error was POST is incorrect. Misleading to people new to apis.
Helped someone who was confused why put request, was returning a POST error